### PR TITLE
Update mask.service.ts

### DIFF
--- a/src/app/ngx-mask/mask.service.ts
+++ b/src/app/ngx-mask/mask.service.ts
@@ -32,7 +32,7 @@ export class MaskService extends MaskApplierService {
   ): string  {
 
     this.maskIsShown = this.showMaskTyped
-        ? this.maskExpression.replace(/[0-9]/g, '_')
+        ? this.maskExpression.replace(/\w/g, '_')
         : '';
     if (!inputValue && this.showMaskTyped) {
       return this.prefix + this.maskIsShown;
@@ -81,7 +81,7 @@ export class MaskService extends MaskApplierService {
 
   public showMaskInInput(): void {
     if (this.showMaskTyped) {
-      this.maskIsShown = this.maskExpression.replace(/[0-9]/g, '_');
+      this.maskIsShown = this.maskExpression.replace(/\w/g, '_');
     }
   }
 


### PR DESCRIPTION
Allow The \w metacharacter is when showing the mask. 

A word character is a character from a-z, A-Z, 0-9, including the _ (underscore) character.

This should probably be dynamic depending on special characters etc. We could also allow different characters instead of just an _(underscore)